### PR TITLE
posts/allの全件取得機能

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -120,9 +120,13 @@ Auth Type Bearer Token
 } []
 ```
 
-<!-- ### userIdから取得
+### userIdから取得
+
+### 例 /?id=1
+
 @Get
-/posts/?userId= :number
+/posts/user/?id= id:number
+
 ```
 {
     id: number,
@@ -131,7 +135,7 @@ Auth Type Bearer Token
     updatedAt: Date,
     userId: number
 } []
-```  -->
+```
 
 ### 投稿作成
 
@@ -144,6 +148,23 @@ Auth Type Bearer Token
     userId: number
 }
 ```
+
+```リターン（例）
+{
+    id: number,
+    content: string,
+    ceratedAt: Date,
+    updatedAt: Date,
+    userLd: number
+}
+```
+
+### 投稿削除
+
+@Delete
+/posts/?id= :number
+
+例：/?id=1
 
 ```リターン（例）
 {

--- a/backend/README.md
+++ b/backend/README.md
@@ -105,9 +105,11 @@ Auth Type Bearer Token
 
 ## 投稿
 
-<!-- ### 全件取得
+### 全件取得
+
 @Get
 /posts/all
+
 ```
 {
     id: number,
@@ -117,7 +119,8 @@ Auth Type Bearer Token
     userId: number
 } []
 ```
-### userIdから取得
+
+<!-- ### userIdから取得
 @Get
 /posts/?userId= :number
 ```
@@ -128,7 +131,7 @@ Auth Type Bearer Token
     updatedAt: Date,
     userId: number
 } []
-``` -->
+```  -->
 
 ### 投稿作成
 

--- a/backend/src/post/post.controller.ts
+++ b/backend/src/post/post.controller.ts
@@ -13,7 +13,8 @@ export class PostController {
       return newPost;
     }
 
-    @Get('/allpost')
+    //今は全件取得だが、今後は最新３０件とか、ランダム３０件とかになるらしい
+    @Get('/all')
     getAllPost(){
         return this.postService.getAllPost();
     }

--- a/backend/src/post/post.controller.ts
+++ b/backend/src/post/post.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Query, Get, Post, Body, HttpCode, HttpStatus, Delete } from '@nestjs/common';
 import { PostService } from './post.service';
 import { createPostDTO } from 'src/dto/post.dto';
 
@@ -13,10 +13,25 @@ export class PostController {
       return newPost;
     }
 
+    //idがstring型注意,指定の仕方例：/?id=1
+    @Delete()
+    deletePost(@Query('id') id:string){
+        return this.postService.deletePost(Number(id));
+    }
+
     //今は全件取得だが、今後は最新３０件とか、ランダム３０件とかになるらしい
     @Get('/all')
     getAllPost(){
-        return this.postService.getAllPost();
+      return this.postService.getAllPost();
     }
+
+    //idがstring型注意,指定の仕方例：user/?id=1
+    @Get('/user')
+    getUserPost(@Query('id') id:string){
+      return this.postService.getUserPost(Number(id));
+    }
+    
+    
+
 
 }

--- a/backend/src/post/post.service.ts
+++ b/backend/src/post/post.service.ts
@@ -13,6 +13,21 @@ export class PostService {
         return post;
     }
 
+    async getUserPost(userId:number){
+        const userPost = await this.prismaService.post.findMany({
+            where:{userId: userId},
+            select:{
+                id: true,
+                content: true,
+                createdAt: true,
+                updatedAt: true,
+                userId: true,
+            },
+        })
+        return userPost;
+    }
+
+
     async createPost(reatePostDTO:createPostDTO){
         const newPost = await this.prismaService.post.create({
             data:{
@@ -23,5 +38,12 @@ export class PostService {
         return newPost;
     }
 
+    async deletePost(postId:number){
+        const deleteUserId = await this.prismaService.post.delete({
+            where:{id: postId},
+            //select:{userId:true},
+        })
+        return deleteUserId;
+        }
 
 }


### PR DESCRIPTION
## 実装した機能
全件取得のエンドポイントをposts/allpost　->　posts/allに変更して、READMEに型の説明を追加。