### PR TITLE
サイドメニューのプロフィールボタン実装

### DIFF
--- a/frontend/src/home_and_profile/CreatePost.tsx
+++ b/frontend/src/home_and_profile/CreatePost.tsx
@@ -13,7 +13,7 @@ type sendData = {
 export default function CreatePost() {
     const nav = useNavigate();
     const [cookies] = useCookies();
-    const formHook = useForm<sendData>({defaultValues:{userId:1, content:''}} );    //本当はクッキーにuserIDが入る
+    const formHook = useForm<sendData>({defaultValues:{userId:cookies.user_id, content:''}} );
 
     // 投稿時の動作
     const onSubmitForm = async(data: sendData) => {

--- a/frontend/src/home_and_profile/CreatePost.tsx
+++ b/frontend/src/home_and_profile/CreatePost.tsx
@@ -13,7 +13,7 @@ type sendData = {
 export default function CreatePost() {
     const nav = useNavigate();
     const [cookies] = useCookies();
-    const formHook = useForm<sendData>({defaultValues:{userId:1, content:''}} );//本当はクッキーにuserIDが入る
+    const formHook = useForm<sendData>({defaultValues:{userId:1, content:''}} );    //本当はクッキーにuserIDが入る
 
     // 投稿時の動作
     const onSubmitForm = async(data: sendData) => {
@@ -24,13 +24,13 @@ export default function CreatePost() {
 
         console.log(data);
         const res = await fetch('http://localhost:3001/posts', {
-                method:"POST",
-                headers: {
-                    'Authorization': 'Bearer ' + cookies.access_token,
-                    "Content-Type": "application/json",
-                },
-                body:JSON.stringify(data),
-            });
+                        method:"POST",
+                        headers: {
+                            'Authorization': 'Bearer ' + cookies.access_token,
+                            "Content-Type": "application/json",
+                        },
+                        body:JSON.stringify(data),
+                    });
         if (!res.ok) {
             console.log(res.statusText);
         }

--- a/frontend/src/home_and_profile/Post.tsx
+++ b/frontend/src/home_and_profile/Post.tsx
@@ -6,7 +6,11 @@ export type postData = {
     content: string;
     createdAt:Date;
     updatedAt:Date;
-    userId:number;
+    userId: number;
+    user: {
+        id: number
+        name: string
+    }
 }
 
 export default function Post({ data }: { data:postData }) {

--- a/frontend/src/home_and_profile/Profile.tsx
+++ b/frontend/src/home_and_profile/Profile.tsx
@@ -60,7 +60,7 @@ async function getProfileJson(): Promise<profileData> {
     const { userId } = useParams<{ userId:string }>();
     const [cookies] = useCookies();
 
-    const res = await fetch(`http://localhost:3001/users/profile/?id=${userId}`, {
+    const res = await fetch(`http://localhost:3001/users/profile?id=${userId}`, {
                     method:"GET",
                     headers: {
                         'Authorization': 'Bearer ' + cookies.access_token,

--- a/frontend/src/home_and_profile/Profile.tsx
+++ b/frontend/src/home_and_profile/Profile.tsx
@@ -2,7 +2,9 @@ import ViewPosts from "./ViewPosts";
 import { useParams } from "react-router-dom";
 import SideBar from "./SideBar";
 import ResolvePromise, { asyncData } from "@/utils/ResolvePromise";
+import { useCookies } from "react-cookie";
 
+// ユーザーのプロフィール情報の型
 type profileData = {
     id: number;
     name: string;
@@ -23,33 +25,21 @@ export default function Profile() {
             </div>
             
             <div className='basis-2/3 m-5'>
-                <h1>プロフ画面 userId={userId}</h1>
-                <ResolvePromise<profileData>
+
+                <ResolvePromise<profileData>    /* プロフィールの表示 */
                     promise={ getProfileJson() }
                     loading={ <div>Loading...</div> }
                     error={ <div>エラーが発生しました</div> }
                     renderItem={ (data: asyncData<profileData>) =>
                         <ProfileHeader data={data} />
                 }/>
-                <ViewPosts postsURL='http://localhost:3001/posts/all' />
+
+                {/* ユーザーの投稿一覧の表示 */}
+                <ViewPosts postsURL={`http://localhost:3001/posts/user?id=${userId}`} />
+
             </div>
         </div>
     )
-}
-
-async function getProfileJson(): Promise<profileData> {
-    const { userId } = useParams<{ userId:string }>();
-
-    const res = await fetch(`http://localhost:3001/users/profile/?id=${userId}`, {
-                    method:"GET",
-                    headers: {
-                        'Content-Type': 'application/json',
-                    }
-                });
-    if (!res.ok) {
-        throw new Error(res.statusText);
-    }
-    return await res.json();
 }
 
 // プロフィールを表示するコンポーネント
@@ -63,4 +53,22 @@ function ProfileHeader({data}: {data: asyncData<profileData>}) {
             <div>idは{ profileData.id }</div>
         </div>
     )
+}
+
+// プロフィール情報を取得する関数
+async function getProfileJson(): Promise<profileData> {
+    const { userId } = useParams<{ userId:string }>();
+    const [cookies] = useCookies();
+
+    const res = await fetch(`http://localhost:3001/users/profile/?id=${userId}`, {
+                    method:"GET",
+                    headers: {
+                        'Authorization': 'Bearer ' + cookies.access_token,
+                        'Content-Type': 'application/json',
+                    }
+                });
+    if (!res.ok) {
+        throw new Error(res.statusText);
+    }
+    return await res.json();
 }

--- a/frontend/src/home_and_profile/Profile.tsx
+++ b/frontend/src/home_and_profile/Profile.tsx
@@ -41,11 +41,11 @@ async function getProfileJson(): Promise<profileData> {
     const { userId } = useParams<{ userId:string }>();
 
     const res = await fetch(`http://localhost:3001/users/profile/?id=${userId}`, {
-            method:"GET",
-            headers: {
-                'Content-Type': 'application/json',
-            }
-        });
+                    method:"GET",
+                    headers: {
+                        'Content-Type': 'application/json',
+                    }
+                });
     if (!res.ok) {
         throw new Error(res.statusText);
     }

--- a/frontend/src/home_and_profile/SideBar.tsx
+++ b/frontend/src/home_and_profile/SideBar.tsx
@@ -1,7 +1,9 @@
 import { Button } from "@/components/ui/Button";
 import { useNavigate } from "react-router-dom"
+import { useCookies } from "react-cookie";
 
 export default function SideBar() {
+    const [cookies] = useCookies();
     const nav = useNavigate();
 
     return (
@@ -13,7 +15,7 @@ export default function SideBar() {
             </Button>
             <Button
                 variant='ghost'
-                onClick={ () => nav(`/profile/${1}`) }> {/*クッキーのuserIDを使う*/}
+                onClick={ () => nav(`/profile/${cookies.user_id}`) }>
                     マイプロフィール
             </Button>
             <Button

--- a/frontend/src/login_and_register/Login.tsx
+++ b/frontend/src/login_and_register/Login.tsx
@@ -5,9 +5,10 @@ import { Input } from "@/components/ui/Input";
 import { useNavigate } from "react-router-dom";
 import { useCookies } from "react-cookie";
 import { hashTextSHA256 } from "@/utils/utils";
+import { useState } from "react";
 
 export type accountData = {
-    user_id: number 
+    user_id: number
     name: string,
     createdAt: Date,
     updatedAt: Date,
@@ -73,9 +74,10 @@ export default function Login() {
                     {/* ログインボタン */}
                     <div className="mx-10 my-5 flex flex-row-reverse justify-between">
                         <Button
-                            variant="default"
-                            type="submit"> ログイン </Button>
+                            type="submit"
+                            variant="default" > ログイン </Button>
                         <Button
+                            type="button"
                             variant="outline"
                             onClick={() => nav("/register")} > 新規登録 </Button>
                     </div>
@@ -112,29 +114,42 @@ export function EmailFormField({ form }: {form: UseFormReturn}) {
 }
 
 export function PWFormField({ form }: {form: UseFormReturn}) {
+    const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
     return (
-        <FormField
-        control={form.control}
-        name="password"
-        defaultValue=""
-        rules={{required:'パスワードを入力してください。',
-                minLength: {value:8, message:'パスワードは8文字以上でなければなりません。'},
-                maxLength: {value:30, message:'パスワードは30文字以下でなければなりません。'},
-                pattern: {value:/[a-zA-Z]+[0-9]+[^a-zA-z0-9]*/, message:'アルファベットと数字がそれぞれ1文字以上必要です。'}
-                }}
-        render={({ field }) => (
-            <FormItem>
-                <FormLabel> Password </FormLabel>
-                <FormControl>
-                    <Input
-                        type="text" 
-                        placeholder="パスワード"
-                        {...field}
-                    />
-                </FormControl>
-                <FormDescription />
-                <FormMessage />
-            </FormItem>
-        )}/>
+        <>
+            <FormField
+            control={form.control}
+            name="password"
+            defaultValue=""
+            rules={{required:'パスワードを入力してください。',
+                    minLength: {value:8, message:'パスワードは8文字以上でなければなりません。'},
+                    maxLength: {value:30, message:'パスワードは30文字以下でなければなりません。'},
+                    pattern: {value:/[a-zA-Z]+[0-9]+[^a-zA-z0-9]*/, message:'アルファベットと数字がそれぞれ1文字以上必要です。'}
+                    }}
+            render={({ field }) => (
+                <FormItem>
+                    <FormLabel> Password </FormLabel>
+                    <FormControl>
+                        <Input
+                            type = {isPasswordVisible ? "text" : "password"}
+                            placeholder = "パスワード"
+                            {...field}
+                        />
+                    </FormControl>
+                    <FormDescription />
+                    <FormMessage />
+                </FormItem>
+            )}/>
+            <Button
+                className=""
+                type="button"
+                variant="outline"
+                onMouseDown={ () => {setIsPasswordVisible(true)} }  /* ボタンを押したら表示 */
+                onMouseUp={ () => {setIsPasswordVisible(false)} }  /* ボタンを離したら非表示 */
+            >
+                {isPasswordVisible ? "非表示" : "表示"}
+            </Button>
+        </>
     )
 }

--- a/frontend/src/login_and_register/Login.tsx
+++ b/frontend/src/login_and_register/Login.tsx
@@ -7,7 +7,11 @@ import { useCookies } from "react-cookie";
 import { hashTextSHA256 } from "@/utils/utils";
 
 export type accountData = {
-    access_token: string;
+    user_id: number 
+    name: string,
+    createdAt: Date,
+    updatedAt: Date,
+    access_token: string
 };
 
 // ログイン画面のコンポーネント
@@ -39,7 +43,12 @@ export default function Login() {
             }
             const accountData: accountData = await res.json();
             
-            setCookie('access_token', accountData.access_token, { maxAge : 3600 });
+            const dataAge = 3600;   // データがクッキーに保存される時間＝1時間
+            setCookie('user_id', accountData.user_id, { maxAge : dataAge });
+            setCookie('name', accountData.name, { maxAge : dataAge });
+            setCookie('createdAt', accountData.createdAt, { maxAge : dataAge });
+            setCookie('updatedAt', accountData.updatedAt, { maxAge : dataAge });
+            setCookie('access_token', accountData.access_token, { maxAge : dataAge });
             nav('/');
 
         } else { console.log('登録データの型が間違っています') }
@@ -108,11 +117,11 @@ export function PWFormField({ form }: {form: UseFormReturn}) {
         control={form.control}
         name="password"
         defaultValue=""
-        rules={{ required:'パスワードを入力してください。',
-                 minLength: {value:8, message:'パスワードは8文字以上でなければなりません。'},
-                 maxLength: {value:30, message:'パスワードは30文字以下でなければなりません。'},
-                 pattern: {value:/[a-zA-Z]+[0-9]+[^a-zA-z0-9]*/, message:'アルファベットと数字がそれぞれ1文字以上必要です。'}
-                 }}
+        rules={{required:'パスワードを入力してください。',
+                minLength: {value:8, message:'パスワードは8文字以上でなければなりません。'},
+                maxLength: {value:30, message:'パスワードは30文字以下でなければなりません。'},
+                pattern: {value:/[a-zA-Z]+[0-9]+[^a-zA-z0-9]*/, message:'アルファベットと数字がそれぞれ1文字以上必要です。'}
+                }}
         render={({ field }) => (
             <FormItem>
                 <FormLabel> Password </FormLabel>

--- a/frontend/src/login_and_register/Register.tsx
+++ b/frontend/src/login_and_register/Register.tsx
@@ -39,7 +39,12 @@ export default function Register() {
             }
             const accountData: accountData = await res.json();
 
-            setCookie('access_token', accountData.access_token, { maxAge : 3600 });
+            const dataAge = 3600;   // データがクッキーに保存される時間＝1時間
+            setCookie('user_id', accountData.user_id, { maxAge : dataAge });
+            setCookie('name', accountData.name, { maxAge : dataAge });
+            setCookie('createdAt', accountData.createdAt, { maxAge : dataAge });
+            setCookie('updatedAt', accountData.updatedAt, { maxAge : dataAge });
+            setCookie('access_token', accountData.access_token, { maxAge : dataAge });
             nav('/');
         } else { console.log('登録データの型が間違っています') }
     }


### PR DESCRIPTION
## 実装した機能

ログイン時にユーザー情報をクッキーに保存
左のプロフィールボタンで自分のプロフィールに遷移可能
ログイン＆新規登録画面のパスワードを隠せる
投稿時に自身のアカウントに投稿できるように変更

## 補足
TODO
- [ ] viewPostに投稿更新機能を付ける（新規投稿時や下に画面を動かしたとき）
- [ ] ログイン＆新規登録画面に戻るボタンを付ける
